### PR TITLE
Add config validator policies and library

### DIFF
--- a/lib/constraints.rego
+++ b/lib/constraints.rego
@@ -1,0 +1,36 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package validator.gcp.lib
+
+# Function to fetch the constraint spec
+# Usage:
+# get_constraint_params(constraint, params)
+
+get_constraint_params(constraint) = params {
+	params := constraint.spec.parameters
+}
+
+# Function to fetch constraint info
+# Usage:
+# get_constraint_info(constraint, info)
+
+get_constraint_info(constraint) = info {
+	info := {
+		"name": constraint.metadata.name,
+		"kind": constraint.kind,
+	}
+}

--- a/lib/util.rego
+++ b/lib/util.rego
@@ -1,0 +1,46 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package validator.gcp.lib
+
+# has_field returns whether an object has a field
+has_field(object, field) {
+	object[field]
+}
+
+# False is a tricky special case, as false responses would create an undefined document unless
+# they are explicitly tested for
+has_field(object, field) {
+	object[field] == false
+}
+
+has_field(object, field) = false {
+	not object[field]
+	not object[field] == false
+}
+
+# get_default returns the value of an object's field or the provided default value.
+# It avoids creating an undefined state when trying to access an object attribute that does
+# not exist
+get_default(object, field, _default) = output {
+	has_field(object, field)
+	output = object[field]
+}
+
+get_default(object, field, _default) = output {
+	has_field(object, field) == false
+	output = _default
+}

--- a/lib/util_test.rego
+++ b/lib/util_test.rego
@@ -1,0 +1,51 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package validator.gcp.lib
+
+# has_field tests
+test_has_field_exists {
+	obj := {"a": "b"}
+	true == has_field(obj, "a")
+}
+
+# False is a tricky special case, as false responses would create an undefined document unless
+# they are explicitly tested for
+test_has_field_false {
+	obj := {"a": false}
+	true == has_field(obj, "a")
+}
+
+test_has_field_no_field {
+	obj := {}
+	false == has_field(obj, "a")
+}
+
+# get_default_tests
+test_get_default_exists {
+	obj := {"a": "b"}
+	"b" == get_default(obj, "a", "q")
+}
+
+test_get_default_not_exists {
+	obj := {}
+	"q" == get_default(obj, "a", "q")
+}
+
+test_get_default_has_false {
+	obj := {"a": false}
+	false == get_default(obj, "a", "b")
+}

--- a/policies/constraints/iam_allowed_policy_member_domains.yaml
+++ b/policies/constraints/iam_allowed_policy_member_domains.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedPolicyMemberDomainsConstraint
+metadata:
+  name: allow_everything
+spec:
+  severity: high
+  match:
+    target: ["organizations/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    domains:
+      - gserviceaccount.com
+      - google.com
+      - notgoogle.com

--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -1,0 +1,76 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-iam-allowed-policy-member-domains
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPIAMAllowedPolicyMemberDomainsConstraint
+        listKind: GCPIAMAllowedPolicyMemberDomainsConstraintList
+        plural: GCPIAMAllowedPolicyMemberDomainsConstraints
+        singular: GCPIAMAllowedPolicyMemberDomainsConstraint
+      validation:
+        openAPIV3Schema:
+          properties:
+            # Domain must not start with '.' or '@'.
+            domains:
+              type: array
+              items: string
+  targets:
+   validation.gcp.forsetisecurity.org:
+      rego: |
+           #INLINE("validator/iam_allowed_policy_member_domains.rego")
+           #
+           # Copyright 2019 Google LLC
+           #
+           # Licensed under the Apache License, Version 2.0 (the "License");
+           # you may not use this file except in compliance with the License.
+           # You may obtain a copy of the License at
+           #
+           #      http://www.apache.org/licenses/LICENSE-2.0
+           #
+           # Unless required by applicable law or agreed to in writing, software
+           # distributed under the License is distributed on an "AS IS" BASIS,
+           # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           # See the License for the specific language governing permissions and
+           # limitations under the License.
+           #
+           
+           package templates.gcp.GCPIAMAllowedPolicyMemberDomainsConstraint
+           
+           import data.validator.gcp.lib as lib
+           
+           # If a primary domain is whitelisted, all of its sub domains are whitelisted as well.
+           deny[{
+           	"msg": message,
+           	"details": metadata,
+           }] {
+           	constraint := input.constraint
+           	lib.get_constraint_params(constraint, params)
+           	asset := input.asset
+           	iam_policy := asset.iam_policy
+           	unique_members := {m | m = iam_policy.bindings[_].members[_]}
+           	member := unique_members[_]
+           	matched_domains := [m | m = member; re_match(sprintf("[@.]%v$", [params.domains[_]]), member)]
+           	count(matched_domains) == 0
+           
+           	message := sprintf("IAM policy for %v contains member from unexpected domain: %v", [asset.name, member])
+           
+           	metadata := {"member": member}
+           }
+           #ENDINLINE


### PR DESCRIPTION
The "lib" directory contains the utility helper functions.
The "policies" directory contains the templates and constraints. For now I've only added the IAM policy one.