### PR TITLE
Update the domain regex to include ":"

### DIFF
--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -66,7 +66,7 @@ spec:
            	iam_policy := asset.iam_policy
            	unique_members := {m | m = iam_policy.bindings[_].members[_]}
            	member := unique_members[_]
-           	matched_domains := [m | m = member; re_match(sprintf("[@.]%v$", [params.domains[_]]), member)]
+           	matched_domains := [m | m = member; re_match(sprintf("[:@.]%v$", [params.domains[_]]), member)]
            	count(matched_domains) == 0
            
            	message := sprintf("IAM policy for %v contains member from unexpected domain: %v", [asset.name, member])


### PR DESCRIPTION
IAM policy member can include all entities from a domain. Example: "domain:google.com"